### PR TITLE
base lower bound

### DIFF
--- a/siphash.cabal
+++ b/siphash.cabal
@@ -15,7 +15,7 @@ Homepage:            http://github.com/vincenthz/hs-siphash
 data-files:          README.md
 
 Library
-  Build-Depends:     base >= 4 && < 6, bytestring, cpu
+  Build-Depends:     base >= 4.5 && < 6, bytestring, cpu
   Exposed-modules:   Crypto.MAC.SipHash
 
 Test-Suite test-siphash


### PR DESCRIPTION
`unsafeShiftL` is available since `base-4.5.0.0`

*EDIT* I made appropriate revisions on Hackage